### PR TITLE
ADLS Gen1 • Remove unnecessary usage of data blocks

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 resource "azurerm_data_lake_store" "adlsg1" {
   name                = var.adls_name
-  resource_group_name = data.azurerm_resource_group.tamr_rg.name
+  resource_group_name = var.resource_group_name
   location            = var.location
   encryption_state    = "Enabled"
   encryption_type     = "ServiceManaged"
@@ -15,7 +15,7 @@ resource "azurerm_data_lake_store_firewall_rule" "allowed_addresses" {
 
   name                = "${var.adls_name}-rule-${count.index}"
   account_name        = var.adls_name
-  resource_group_name = data.azurerm_resource_group.tamr_rg.name
+  resource_group_name = var.resource_group_name
   start_ip_address    = var.allowed_ips[count.index]
   end_ip_address      = var.allowed_ips[count.index]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -8,10 +8,6 @@ variable "location" {
   type        = string
 }
 
-data "azurerm_resource_group" "tamr_rg" {
-  name = var.resource_group_name
-}
-
 variable "adls_name" {
   description = "Name of ADLS Gen1 deployment"
   type        = string


### PR DESCRIPTION
Data blocks like these prevent someone from creating the subnet that they want to use for this module in the same run with this module. This is because the data block requires the subnet to exist before this terraform is run. Here we were just passing in the resource group name to make a data block to get the resource group's name. Since we only use that block to get the name, it makes more sense to just pass the name.

